### PR TITLE
RLPx Handling incoming connections fix

### DIFF
--- a/es/eth/index.js
+++ b/es/eth/index.js
@@ -37,11 +37,6 @@ class ETH extends EventEmitter {
     }, ms('5s'))
   }
 
-  static eth62 = { name: 'eth', version: 62, length: 8, constructor: ETH }
-  static eth63 = { name: 'eth', version: 63, length: 17, constructor: ETH }
-
-  static MESSAGE_CODES = MESSAGE_CODES
-
   _handleMessage (code, data) {
     const payload = rlp.decode(data)
     switch (code) {
@@ -138,5 +133,10 @@ class ETH extends EventEmitter {
     this._send(code, rlp.encode(payload))
   }
 }
+
+ETH.eth62 = { name: 'eth', version: 62, length: 8, constructor: ETH }
+ETH.eth63 = { name: 'eth', version: 63, length: 17, constructor: ETH }
+
+ETH.MESSAGE_CODES = MESSAGE_CODES
 
 module.exports = ETH

--- a/es/rlpx/index.js
+++ b/es/rlpx/index.js
@@ -53,8 +53,6 @@ class RLPx extends EventEmitter {
     this._refillIntervalId = setInterval(() => this._refillConnections(), ms('10s'))
   }
 
-  static DISCONNECT_REASONS = Peer.DISCONNECT_REASONS
-
   listen (...args) {
     this._isAliveCheck()
     debug('call .listen')
@@ -208,5 +206,5 @@ class RLPx extends EventEmitter {
     })
   }
 }
-
+RLPx.DISCONNECT_REASONS = Peer.DISCONNECT_REASONS
 module.exports = RLPx

--- a/es/rlpx/peer.js
+++ b/es/rlpx/peer.js
@@ -77,7 +77,7 @@ class Peer extends EventEmitter {
     this._protocols = []
 
     // send AUTH if outgoing connection
-    if (this._remoteId !== null) this._sendAuth()
+    if (this._remoteId) this._sendAuth()
   }
 
   static DISCONNECT_REASONS = {
@@ -170,7 +170,7 @@ class Peer extends EventEmitter {
           id: payload[4]
         }
 
-        if (this._remoteId === null) {
+        if (!this._remoteId) {
           this._remoteId = Buffer.from(this._hello.id)
         } else if (!this._remoteId.equals(this._hello.id)) {
           return this.disconnect(Peer.DISCONNECT_REASONS.INVALID_IDENTITY)

--- a/es/rlpx/peer.js
+++ b/es/rlpx/peer.js
@@ -80,22 +80,6 @@ class Peer extends EventEmitter {
     if (this._remoteId) this._sendAuth()
   }
 
-  static DISCONNECT_REASONS = {
-    DISCONNECT_REQUESTED: 0x00,
-    NETWORK_ERROR: 0x01,
-    PROTOCOL_ERROR: 0x02,
-    USELESS_PEER: 0x03,
-    TOO_MANY_PEERS: 0x04,
-    ALREADY_CONNECTED: 0x05,
-    INCOMPATIBLE_VERSION: 0x06,
-    INVALID_IDENTITY: 0x07,
-    CLIENT_QUITTING: 0x08,
-    UNEXPECTED_IDENTITY: 0x09,
-    SAME_IDENTITY: 0x0a,
-    TIMEOUT: 0x0b,
-    SUBPROTOCOL_ERROR: 0x10
-  }
-
   _parsePacket (data) {
     switch (this._state) {
       case 'Auth':
@@ -305,4 +289,19 @@ class Peer extends EventEmitter {
   }
 }
 
+Peer.DISCONNECT_REASONS = {
+  DISCONNECT_REQUESTED: 0x00,
+  NETWORK_ERROR: 0x01,
+  PROTOCOL_ERROR: 0x02,
+  USELESS_PEER: 0x03,
+  TOO_MANY_PEERS: 0x04,
+  ALREADY_CONNECTED: 0x05,
+  INCOMPATIBLE_VERSION: 0x06,
+  INVALID_IDENTITY: 0x07,
+  CLIENT_QUITTING: 0x08,
+  UNEXPECTED_IDENTITY: 0x09,
+  SAME_IDENTITY: 0x0a,
+  TIMEOUT: 0x0b,
+  SUBPROTOCOL_ERROR: 0x10
+}
 module.exports = Peer


### PR DESCRIPTION
I was trying to setup an ethereum node to handle incoming connections (based on `examples/inv.js` ) by uncommenting the port binding and connecting part, then running another node on different ports to connect to the first node
```javascript
// first node
// uncomment, if you want accept incoming connections
rlpx.listen(30303, '0.0.0.0')
dpt.bind(30303, '0.0.0.0')

// ===========================

// 2nd node 
rlpx.listen(30304, '0.0.0.0')
dpt.bind(30304, '0.0.0.0')

// connect to local ethereum node (debug)
dpt.addPeer({ address: '127.0.0.1', udpPort: 30303, tcpPort: 30303 })
  .then((peer) => {
    return rlpx.connect({
      id: peer.id,
      address: peer.address,
      port: peer.tcpPort
    })
  })
  .catch((err) => console.log(`error on connection to local node: ${err.stack || err}`))

```

This throws and error in the current version because `this._sendAuth()` is triggered even if it's an incoming connection, because `this._remoteId` is `undefined` and not `null`.  the 2 changes in this commit successfully fixed the issue.

