### PR TITLE
#5 : Remove Peer on close event

### DIFF
--- a/es/rlpx/index.js
+++ b/es/rlpx/index.js
@@ -190,7 +190,8 @@ class RLPx extends EventEmitter {
           ts: Date.now() + ms('5m')
         })
       }
-
+      let peerKey = peer.getId().toString('hex')
+      this._peers.delete(peerKey)
       this.emit('peer:removed', peer, reason, disconnectWe)
     })
   }


### PR DESCRIPTION
#5 Removes the `peer` from `this._peers` on close event