### PR TITLE
Remove src/ directory from npm package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "Holger Drewes <holger.drewes@gmail.com>"
   ],
   "files": [
-    "src",
     "lib"
   ],
   "main": "./lib/index.js",


### PR DESCRIPTION
Fixes #47 

This PR removes the `src/` directory from the npm package files listing to help reduce the size on disk.