### PR TITLE
fix: peer communication example

### DIFF
--- a/src/examples/peer-communication.ts
+++ b/src/examples/peer-communication.ts
@@ -16,9 +16,6 @@ const Common = require('ethereumjs-common').default
 const config = new Common('mainnet')
 const bootstrapNodes = config.bootstrapNodes()
 const BOOTNODES = bootstrapNodes
-  .filter((node: any) => {
-    return node.chainId === CHAIN_ID
-  })
   .map((node: any) => {
     return {
       address: node.ip,

--- a/src/examples/peer-communication.ts
+++ b/src/examples/peer-communication.ts
@@ -15,14 +15,13 @@ const CHAIN_ID = 1
 const Common = require('ethereumjs-common').default
 const config = new Common('mainnet')
 const bootstrapNodes = config.bootstrapNodes()
-const BOOTNODES = bootstrapNodes
-  .map((node: any) => {
-    return {
-      address: node.ip,
-      udpPort: node.port,
-      tcpPort: node.port,
-    }
-  })
+const BOOTNODES = bootstrapNodes.map((node: any) => {
+  return {
+    address: node.ip,
+    udpPort: node.port,
+    tcpPort: node.port,
+  }
+})
 const REMOTE_CLIENTID_FILTER = [
   'go1.5',
   'go1.6',


### PR DESCRIPTION
removes the chainId bootnode filter since this property does not exist on bootnode entries.