### PR TITLE
fix: npm pack

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
     "Holger Drewes <holger.drewes@gmail.com>"
   ],
   "files": [
-    "src/**/*.js",
-    "src/**/*.d.ts",
-    "src/**/*.map"
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
+    "dist/**/*.map"
   ],
-  "main": "dist/src/index.js",
+  "main": "dist/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/ethereumjs/ethereumjs-devp2p.git"


### PR DESCRIPTION
output:
```shell
ethereumjs-devp2p % npm pack --dry-run
npm notice 
npm notice 📦  ethereumjs-devp2p@2.5.1
npm notice === Tarball Contents === 
npm notice 1.9kB  dist/dpt/ban-list.js    
npm notice 12.2kB dist/dpt/dpt.js         
npm notice 15.4kB dist/rlpx/ecies.js      
npm notice 363B   dist/dpt/index.js       
npm notice 8.0kB  dist/eth/index.js       
npm notice 349B   dist/index.js           
npm notice 10.6kB dist/les/index.js       
npm notice 323B   dist/rlpx/index.js      
npm notice 4.9kB  dist/dpt/kbucket.js     
npm notice 1.3kB  dist/rlpx/mac.js        
npm notice 6.2kB  dist/dpt/message.js     
npm notice 20.8kB dist/rlpx/peer.js       
npm notice 15.6kB dist/rlpx/rlpx.js       
npm notice 12.5kB dist/dpt/server.js      
npm notice 3.4kB  dist/util.js            
npm notice 2.8kB  package.json            
npm notice 869B   dist/dpt/ban-list.js.map
npm notice 4.9kB  dist/dpt/dpt.js.map     
npm notice 14.8kB dist/rlpx/ecies.js.map  
npm notice 191B   dist/dpt/index.js.map   
npm notice 5.8kB  dist/eth/index.js.map   
npm notice 170B   dist/index.js.map       
npm notice 7.5kB  dist/les/index.js.map   
npm notice 179B   dist/rlpx/index.js.map  
npm notice 2.6kB  dist/dpt/kbucket.js.map 
npm notice 1.1kB  dist/rlpx/mac.js.map    
npm notice 6.3kB  dist/dpt/message.js.map 
npm notice 14.1kB dist/rlpx/peer.js.map   
npm notice 9.0kB  dist/rlpx/rlpx.js.map   
npm notice 6.9kB  dist/dpt/server.js.map  
npm notice 3.3kB  dist/util.js.map        
npm notice 3.3kB  CHANGELOG.md            
npm notice 12.0kB README.md               
npm notice 139B   dist/dpt/ban-list.d.ts  
npm notice 777B   dist/dpt/dpt.d.ts       
npm notice 1.6kB  dist/rlpx/ecies.d.ts    
npm notice 131B   dist/dpt/index.d.ts     
npm notice 1.7kB  dist/eth/index.d.ts     
npm notice 117B   dist/index.d.ts         
npm notice 2.0kB  dist/les/index.d.ts     
npm notice 96B    dist/rlpx/index.d.ts    
npm notice 557B   dist/dpt/kbucket.d.ts   
npm notice 282B   dist/rlpx/mac.d.ts      
npm notice 370B   dist/dpt/message.d.ts   
npm notice 2.7kB  dist/rlpx/peer.d.ts     
npm notice 1.4kB  dist/rlpx/rlpx.d.ts     
npm notice 1.0kB  dist/dpt/server.d.ts    
npm notice 798B   dist/util.d.ts          
npm notice === Tarball Details === 
npm notice name:          ethereumjs-devp2p                       
npm notice version:       2.5.1                                   
npm notice filename:      ethereumjs-devp2p-2.5.1.tgz             
npm notice package size:  45.7 kB                                 
npm notice unpacked size: 223.6 kB                                
npm notice shasum:        ad4fc248c007b4f7324de28771674a326282f6c8
npm notice integrity:     sha512-ZcISHLPtek5XK[...]O+DDPurCJfTRQ==
npm notice total files:   48                                      
npm notice 
```