### PR TITLE
New verbose logger to debug output

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Communicate with peers to read new transaction and block information:
 Run an example with:
 
 ```
-DEBUG='*devp2p*' node -r ts-node/register ./examples/peer-communication.ts
+DEBUG=devp2p:* node -r ts-node/register ./examples/peer-communication.ts
 ```
 
 ## Distributed Peer Table (DPT) / Node Discovery
@@ -353,7 +353,16 @@ This library uses [debug](https://github.com/visionmedia/debug) debugging utilit
 For the debugging output to show up, set the `DEBUG` environment variable (e.g. in Linux/Mac OS:
 `export DEBUG=*,-babel`).
 
-You should now see debug output like to following when running one of the examples above (the indented lines):
+Use the `DEBUG` environment variable to active the logger output you are interested in, e.g.:
+
+DEBUG=devp2p:dpt:\*,devp2p:eth node -r ts-node/register [YOUR_SCRIPT_TO_RUN.ts]
+
+For more verbose output on logging (e.g. to output the entire msg payload) use the `verbose` logger
+in addition:
+
+DEBUG=devp2p:dpt:\*,devp2p:eth,verbose node -r ts-node/register [YOUR_SCRIPT_TO_RUN.ts]
+
+Exemplary logging output:
 
 ```
 Add peer: 52.3.158.184:30303 Geth/v1.7.3-unstable-479aa61f/linux-amd64/go1.9 (eth63) (total: 2)

--- a/src/dpt/ban-list.ts
+++ b/src/dpt/ban-list.ts
@@ -1,8 +1,10 @@
 import LRUCache from 'lru-cache'
-import Debug from 'debug'
+import { debug as createDebugLogger } from 'debug'
 import { KBucket } from './kbucket'
+import { formatLogId } from '../util'
 
-const debug = Debug('devp2p:dpt:ban-list')
+const debug = createDebugLogger('devp2p:dpt:ban-list')
+const verbose = createDebugLogger('verbose').enabled
 
 export class BanList {
   private lru: LRUCache<any, boolean>
@@ -12,7 +14,7 @@ export class BanList {
 
   add(obj: any, maxAge?: number) {
     for (const key of KBucket.getKeys(obj)) {
-      debug(`add ${key}, size: ${this.lru.length}`)
+      debug(`add ${formatLogId(key, verbose)}, size: ${this.lru.length}`)
       this.lru.set(key, true, maxAge)
     }
   }

--- a/src/les/index.ts
+++ b/src/les/index.ts
@@ -2,10 +2,11 @@ import { EventEmitter } from 'events'
 import rlp from 'rlp-encoding'
 import ms from 'ms'
 import { debug as createDebugLogger } from 'debug'
-import { int2buffer, buffer2int, assertEq } from '../util'
+import { int2buffer, buffer2int, assertEq, formatLogData } from '../util'
 import { Peer, DISCONNECT_REASONS } from '../rlpx/peer'
 
 const debug = createDebugLogger('devp2p:les')
+const verbose = createDebugLogger('verbose').enabled
 
 export const DEFAULT_ANNOUNCE_TYPE = 1
 
@@ -35,11 +36,11 @@ export class LES extends EventEmitter {
   _handleMessage(code: LES.MESSAGE_CODES, data: any) {
     const payload = rlp.decode(data)
     if (code !== LES.MESSAGE_CODES.STATUS) {
-      debug(
-        `Received ${this.getMsgPrefix(code)} message from ${this._peer._socket.remoteAddress}:${
-          this._peer._socket.remotePort
-        }: ${data.toString('hex')}`,
-      )
+      const debugMsg = `Received ${this.getMsgPrefix(code)} message from ${
+        this._peer._socket.remoteAddress
+      }:${this._peer._socket.remotePort}`
+      const logData = formatLogData(data.toString('hex'), verbose)
+      debug(`${debugMsg}: ${logData}`)
     }
     switch (code) {
       case LES.MESSAGE_CODES.STATUS:
@@ -151,11 +152,12 @@ export class LES extends EventEmitter {
   }
 
   sendMessage(code: LES.MESSAGE_CODES, reqId: number, payload: any) {
-    debug(
-      `Send ${this.getMsgPrefix(code)} message to ${this._peer._socket.remoteAddress}:${
-        this._peer._socket.remotePort
-      }: ${rlp.encode(payload).toString('hex')}`,
-    )
+    const debugMsg = `Send ${this.getMsgPrefix(code)} message to ${
+      this._peer._socket.remoteAddress
+    }:${this._peer._socket.remotePort}`
+    const logData = formatLogData(rlp.encode(payload).toString('hex'), verbose)
+    debug(`${debugMsg}: ${logData}`)
+
     switch (code) {
       case LES.MESSAGE_CODES.STATUS:
         throw new Error('Please send status message through .sendStatus')

--- a/src/rlpx/peer.ts
+++ b/src/rlpx/peer.ts
@@ -4,12 +4,13 @@ import * as util from '../util'
 import BufferList from 'bl'
 import ms from 'ms'
 import { debug as createDebugLogger } from 'debug'
-import { int2buffer, buffer2int } from '../util'
+import { int2buffer, buffer2int, formatLogData } from '../util'
 import { ECIES } from './ecies'
 import { Socket } from 'net'
 import { ETH, LES } from '../'
 
 const debug = createDebugLogger('devp2p:rlpx:peer')
+const verbose = createDebugLogger('verbose').enabled
 
 export const BASE_PROTOCOL_VERSION = 4
 export const BASE_PROTOCOL_LENGTH = 16
@@ -221,8 +222,9 @@ export class Peer extends EventEmitter {
         }
 
         debug(
-          `Received body ${this._socket.remoteAddress}:${this._socket.remotePort} ${body.toString(
-            'hex',
+          `Received body ${this._socket.remoteAddress}:${this._socket.remotePort} ${formatLogData(
+            body.toString('hex'),
+            verbose,
           )}`,
         )
 

--- a/src/rlpx/rlpx.ts
+++ b/src/rlpx/rlpx.ts
@@ -7,11 +7,12 @@ import { debug as createDebugLogger } from 'debug'
 import LRUCache from 'lru-cache'
 // note: relative path only valid in .js file in dist
 const { version: pVersion } = require('../../package.json')
-import { pk2id, createDeferred } from '../util'
+import { pk2id, createDeferred, formatLogId } from '../util'
 import { Peer, DISCONNECT_REASONS, Capabilities } from './peer'
 import { DPT, PeerInfo } from '../dpt'
 
 const debug = createDebugLogger('devp2p:rlpx')
+const verbose = createDebugLogger('verbose').enabled
 
 export interface RLPxOptions {
   clientId?: Buffer
@@ -121,7 +122,7 @@ export class RLPx extends EventEmitter {
     if (this._peers.has(peerKey)) throw new Error('Already connected')
     if (this._getOpenSlots() === 0) throw new Error('Too many peers already connected')
 
-    debug(`connect to ${peer.address}:${peer.tcpPort} (id: ${peerKey})`)
+    debug(`connect to ${peer.address}:${peer.tcpPort} (id: ${formatLogId(peerKey, verbose)})`)
     const deferred = createDeferred()
 
     const socket = new net.Socket()

--- a/src/util.ts
+++ b/src/util.ts
@@ -78,6 +78,24 @@ export function assertEq(expected: any, actual: any, msg: string): void {
   })
 }
 
+export function formatLogId(id: string, verbose: boolean): string {
+  const numChars = 7
+  if (verbose) {
+    return id
+  } else {
+    return `${id.substring(0, numChars)}`
+  }
+}
+
+export function formatLogData(data: string, verbose: boolean): string {
+  const maxChars = 60
+  if (verbose || data.length <= maxChars) {
+    return data
+  } else {
+    return `${data.substring(0, maxChars)}...`
+  }
+}
+
 export class Deferred<T> {
   promise: Promise<T>
   resolve: (...args: any[]) => any = () => {}


### PR DESCRIPTION
The current debug output triggered with e.g.

```shell
DEBUG=devp2p:* node -r ts-node/register ./examples/peer-communication.ts
```

is very hard follow and use for debugging since it is extremely verbose, in the case of `ETH` debugging output printing out dozens to hundreds of lines with the full message payloads to the CL.

This PR adds a new `verbose` logger for the debug output which can be used like this:

```shell
DEBUG=devp2p:*,verbose node -r ts-node/register ./examples/peer-communication.ts
```

This preserves the currently implemented behavior. Logging defaults now to a non-verbose output - shortening long peer IDs, block hashes and - most important - message payloads, which should be a lot friendlier for the everyday debug situation.

Exemplary verbose output:

![verbose](https://user-images.githubusercontent.com/931137/83520580-2cd3e280-a4de-11ea-8b6a-63e8b366b8f6.png)

Exemplary non-verbose output, similar situation:

![non_verbose](https://user-images.githubusercontent.com/931137/83520595-32c9c380-a4de-11ea-8cc0-b1d6dd10d7c2.png)
