### PR TITLE
Internalize util logger

### DIFF
--- a/src/dpt/message.ts
+++ b/src/dpt/message.ts
@@ -1,7 +1,10 @@
+import { debug as createDebugLogger } from 'debug'
 import ip from 'ip'
 import rlp from 'rlp-encoding'
 import secp256k1 from 'secp256k1'
 import { keccak256, int2buffer, buffer2int, assertEq } from '../util'
+
+const debug = createDebugLogger('devp2p:dpt:server')
 
 function getTimestamp() {
   return (Date.now() / 1000) | 0
@@ -183,7 +186,7 @@ export function encode<T>(typename: string, data: T, privateKey: Buffer) {
 
 export function decode(buffer: Buffer) {
   const hash = keccak256(buffer.slice(32))
-  assertEq(buffer.slice(0, 32), hash, 'Hash verification failed')
+  assertEq(buffer.slice(0, 32), hash, 'Hash verification failed', debug)
 
   const typedata = buffer.slice(97)
   const type = typedata[0]

--- a/src/eth/index.ts
+++ b/src/eth/index.ts
@@ -46,7 +46,7 @@ export class ETH extends EventEmitter {
     }
     switch (code) {
       case ETH.MESSAGE_CODES.STATUS:
-        assertEq(this._peerStatus, null, 'Uncontrolled status message')
+        assertEq(this._peerStatus, null, 'Uncontrolled status message', debug)
         this._peerStatus = payload
         debug(
           `Received ${this.getMsgPrefix(code)} message from ${this._peer._socket.remoteAddress}:${
@@ -84,9 +84,9 @@ export class ETH extends EventEmitter {
     if (this._status === null || this._peerStatus === null) return
     clearTimeout(this._statusTimeoutId)
 
-    assertEq(this._status[0], this._peerStatus[0], 'Protocol version mismatch')
-    assertEq(this._status[1], this._peerStatus[1], 'NetworkId mismatch')
-    assertEq(this._status[4], this._peerStatus[4], 'Genesis block mismatch')
+    assertEq(this._status[0], this._peerStatus[0], 'Protocol version mismatch', debug)
+    assertEq(this._status[1], this._peerStatus[1], 'NetworkId mismatch', debug)
+    assertEq(this._status[4], this._peerStatus[4], 'Genesis block mismatch', debug)
 
     this.emit('status', {
       networkId: this._peerStatus[1],

--- a/src/les/index.ts
+++ b/src/les/index.ts
@@ -44,7 +44,7 @@ export class LES extends EventEmitter {
     }
     switch (code) {
       case LES.MESSAGE_CODES.STATUS:
-        assertEq(this._peerStatus, null, 'Uncontrolled status message')
+        assertEq(this._peerStatus, null, 'Uncontrolled status message', debug)
         let statusArray: any = {}
         payload.forEach(function(value: any) {
           statusArray[value[0].toString()] = value[1]
@@ -96,9 +96,15 @@ export class LES extends EventEmitter {
       this._status['protocolVersion'],
       this._peerStatus['protocolVersion'],
       'Protocol version mismatch',
+      debug,
     )
-    assertEq(this._status['networkId'], this._peerStatus['networkId'], 'NetworkId mismatch')
-    assertEq(this._status['genesisHash'], this._peerStatus['genesisHash'], 'Genesis block mismatch')
+    assertEq(this._status['networkId'], this._peerStatus['networkId'], 'NetworkId mismatch', debug)
+    assertEq(
+      this._status['genesisHash'],
+      this._peerStatus['genesisHash'],
+      'Genesis block mismatch',
+      debug,
+    )
 
     this.emit('status', this._peerStatus)
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,10 +1,7 @@
 import { randomBytes } from 'crypto'
 import { privateKeyVerify, publicKeyConvert } from 'secp256k1'
-import { debug as createDebugLogger } from 'debug'
 import createKeccakHash from 'keccak'
 import assert from 'assert'
-
-const debug = createDebugLogger('devp2p:util')
 
 export function keccak256(...buffers: Buffer[]) {
   const buffer = Buffer.concat(buffers)
@@ -59,12 +56,12 @@ export function xor(a: Buffer, b: any): Buffer {
   return buffer
 }
 
-export function assertEq(expected: any, actual: any, msg: string): void {
+export function assertEq(expected: any, actual: any, msg: string, debug: any): void {
   let message
   if (Buffer.isBuffer(expected) && Buffer.isBuffer(actual)) {
     if (expected.equals(actual)) return
     message = `${msg}: ${expected.toString('hex')} / ${actual.toString('hex')}`
-    debug(message)
+    debug(`[ERROR]  ${message}`)
     throw new assert.AssertionError({
       message: message,
     })


### PR DESCRIPTION
The 'devp2p:util'  logger was always a bit of an alien with no semantics, being used for logging output from the generic `assertEq` function. This lead to the case that a) errors are not associated to a corresponding logger and therefore are more difficult to track and b) not logged at all when not using 'devp2p:*' but a selected logger like 'devp2p:rlpx'.

This PR fixes this and removes the 'devp2p:util'  logger. A logger ('debug') is instead passed to the 'assertEq' method from the respective modules and the error gets logged in a context-aware manner.

Example:

```shell
  devp2p:rlpx:peer Received header 88.99.67.109:30303 +1ms
  devp2p:rlpx:peer Received body 88.99.67.109:30303 01c104 +0ms
  devp2p:rlpx:peer Received DISCONNECT (message code: 1 - 0 = 1) 88.99.67.109:30303 +0ms
  devp2p:rlpx refill connections.. queue size: 1, open slots: 11 +1ms
  devp2p:rlpx:peer [ERROR] wrong ecies header (possible cause: EIP8 upgrade): 01 / 04 +2ms
  devp2p:rlpx:peer Received ack (EIP8) from 147.135.182.139:30303 +2ms
  devp2p:rlpx:peer Send HELLO to 147.135.182.139:30303 +0ms
  devp2p:rlpx:peer Received body 54.39.51.192:30303 14fa010aa2f90215a0937afb3fa16cf335836f9345652bdb58787f444add... +14ms
  devp2p:rlpx:peer Received undefined (message code: 20 - 16 = 4) 54.39.51.192:30303 +1ms
```