### PR TITLE
[RLPx] add option to connect to remote hosts from a predefined local port

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Creates new RLPx object
 - `options.remoteClientIdFilter` - Optional list of client ID filter strings (e.g. `['go1.5', 'quorum']`).
 - `options.capabilities` - Upper layer protocol capabilities, e.g. `[devp2p.ETH.eth63, devp2p.ETH.eth62]`.
 - `options.listenPort` - The listening port for the server or `null` for default.
+- `options.connectPort` - The default local connection port to connect with remote peers with: if `undefined`, connect from a random local port.
 - `options.dpt` - `DPT` object for the peers to connect to (default: `null`, no `DPT` peer management).
 
 #### `rlpx.connect(peer)` (`async`)


### PR DESCRIPTION
When playing around with this library and trying to connect to my local node, I noticed that even when I set `RLPx`'s `listenPort` it would connect from random local ports to my node. I would expect that it would use `listenPort` to connect from, but this is apparently not done.

This is handy, because for instance in Geth you can then set this peer as a "trusted peer" and keep this peer in the peer pool. However, you need the IP and the port for this to add the trusted peer: if this keeps changing this is annoying.

I tried not adding this `connectPort` option and instead just using `listenPort` but this breaks the tests. I am not sure if this is due to the tests or that there is a fundamental problem by defaulting it to `listenPort` (I think it is due to the tests?).