### PR TITLE
Switch to Codecov

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,9 @@ jobs:
       - uses: actions/checkout@v1
       - run: npm install
       - run: npm run coverage
-      - name: Upload coverage to Coveralls
-        uses: coverallsapp/github-action@master
+      - uses: codecov/codecov-action@v1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./coverage/lcov.info
 
   test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # ethereumjs-devp2p
 
-[![NPM Package](https://img.shields.io/npm/v/ethereumjs-devp2p.svg)](https://www.npmjs.org/package/ethereumjs-devp2p)
-[![Actions Status](https://github.com/ethereumjs/ethereumjs-devp2p/workflows/Build/badge.svg)](https://github.com/ethereumjs/ethereumjs-devp2p/actions)
-[![Coverage Status](https://img.shields.io/coveralls/ethereumjs/ethereumjs-devp2p.svg)](https://coveralls.io/r/ethereumjs/ethereumjs-devp2p)
-
-[![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
+[![NPM Status][npm-badge]][npm-link]
+[![Actions Status][actions-badge]][actions-link]
+[![Coverage Status][coverage-badge]][coverage-link]
+[![Discord][discord-badge]][discord-link]
 
 This library bundles different components for lower-level peer-to-peer connection and message exchange:
 
@@ -398,3 +397,12 @@ The following is a list of major implementations of the `devp2p` stack in other 
 ## License
 
 MIT
+
+[npm-badge]: https://img.shields.io/npm/v/ethereumjs-devp2p.svg
+[npm-link]: https://www.npmjs.org/package/ethereumjs-devp2p
+[actions-badge]: https://github.com/ethereumjs/ethereumjs-devp2p/workflows/Build/badge.svg
+[actions-link]: https://github.com/ethereumjs/ethereumjs-devp2p/actions
+[coverage-badge]: https://codecov.io/gh/ethereumjs/ethereumjs-devp2p/branch/master/graph/badge.svg
+[coverage-link]: https://codecov.io/gh/ethereumjs/ethereumjs-devp2p
+[discord-badge]: https://img.shields.io/static/v1?logo=discord&label=discord&message=Join&color=blue
+[discord-link]: https://discord.gg/TNwARpR

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        base: auto 


### PR DESCRIPTION
This PR switches the repository coverage provider from Coveralls to Codecov in preparation for merging into the ethereumjs-vm monorepo.